### PR TITLE
Fix ability to use both Enzyme and Puppeteer

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,20 +69,33 @@
 		"typescript": "^3.7.3"
 	},
 	"jest": {
-		"collectCoverage": true,
-		"coverageDirectory": "./coverage/",
-		"coveragePathIgnorePatterns": [
-			"/node_modules/",
-			"<rootDir>/test/"
-		],
-		"preset": "jest-puppeteer",
-		"setupFilesAfterEnv": [
-			"<rootDir>test/setupTests.ts"
-		],
-		"testMatch": [
-			"**/*.test.ts",
-			"**/*.test.tsx"
-		],
-		"verbose": true
+		"projects": [
+			{
+				"displayName": "Enzyme",
+				"collectCoverage": true,
+				"coverageDirectory": "./coverage/",
+				"coveragePathIgnorePatterns": [
+					"/node_modules/",
+					"<rootDir>/test/"
+				],
+				"setupFilesAfterEnv": [
+					"<rootDir>/test/setupTests.ts"
+				],
+				"testMatch": [
+					"<rootDir>/test/*.test.ts",
+					"<rootDir>/test/*.test.tsx"
+				],
+				"verbose": true
+			},
+			{
+				"displayName": "Puppeteer",
+				"preset": "jest-puppeteer",
+				"testMatch": [
+					"<rootDir>/test/puppeteer/*.test.ts",
+					"<rootDir>/test/puppeteer/*.test.tsx"
+				],
+				"verbose": true
+			}
+		]
 	}
 }


### PR DESCRIPTION
Now we have two separate Jest projects with entirely different configurations.