### PR TITLE
Tell CRA to use relative paths

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "demo",
 	"version": "0.0.0",
+	"homepage": ".",
 	"dependencies": {
 		"@testing-library/jest-dom": "^4.2.4",
 		"@testing-library/react": "^9.3.2",


### PR DESCRIPTION
This allows the `index.html` file to be opened directly, rather than needing a web server to run.