### PR TITLE
Rethink behavior on button clicks

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ Done!
 ## Accessibility notes
 Our team carefully studied and adhered to [Web Content Accessibility Guidelines 2.1](https://www.w3.org/WAI/standards-guidelines/wcag/) and  [WAI-ARIA Authoring Practices 1.1](https://www.w3.org/TR/wai-aria-practices/) when designing this Hook. Here are some facets of accessibility that are handled automatically:
 
-- Strict adherence to the best practices for menus ([WAI-ARIA: 3.15](https://www.w3.org/TR/wai-aria-practices/#menu))
+- Careful following of the best practices for menus ([WAI-ARIA: 3.15](https://www.w3.org/TR/wai-aria-practices/#menu))
+  - The only deviation is that the first menu item is only focused when the menu is revealed via the keyboard ([see why](https://github.com/sparksuite/react-accessible-dropdown-menu-hook/pull/63))
 - Strict adherence to the best practices for menu buttons ([WAI-ARIA: 3.16](https://www.w3.org/TR/wai-aria-practices/#menubutton))
 - Full keyboard accessibility ([WCAG: 2.1](https://www.w3.org/WAI/WCAG21/quickref/#keyboard-accessible))
 - Use of ARIA properties and roles to establish relationships amongst elements ([WCAG: 1.3.1](https://www.w3.org/WAI/WCAG21/quickref/#info-and-relationships))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "react-accessible-dropdown-menu-hook",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"description": "A simple Hook for creating fully accessible dropdown menus in React",
 	"main": "dist/use-dropdown-menu.js",
 	"types": "dist/use-dropdown-menu.d.ts",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
 		"collectCoverageFrom": [
 			"<rootDir>/src/**"
 		],
+		"verbose": true,
 		"projects": [
 			{
 				"displayName": "Enzyme",
@@ -86,8 +87,7 @@
 				"testMatch": [
 					"<rootDir>/test/*.test.ts",
 					"<rootDir>/test/*.test.tsx"
-				],
-				"verbose": true
+				]
 			},
 			{
 				"displayName": "Puppeteer",
@@ -95,8 +95,7 @@
 				"testMatch": [
 					"<rootDir>/test/puppeteer/*.test.ts",
 					"<rootDir>/test/puppeteer/*.test.tsx"
-				],
-				"verbose": true
+				]
 			}
 		]
 	}

--- a/src/use-dropdown-menu.ts
+++ b/src/use-dropdown-menu.ts
@@ -7,6 +7,7 @@ export default function useDropdownMenu(itemCount: number) {
 	const [isOpen, setIsOpen] = useState<boolean>(false);
 	const currentFocusIndex = useRef<number | null>(null);
 	const firstRun = useRef(true);
+	const clickedOpen = useRef(false);
 
 	// Create refs
 	const buttonRef = useRef<HTMLButtonElement>(null);
@@ -31,8 +32,10 @@ export default function useDropdownMenu(itemCount: number) {
 		}
 
 		// If the menu is currently open focus on the first item in the menu
-		if (isOpen) {
+		if (isOpen && !clickedOpen.current) {
 			moveFocus(0);
+		} else if (!isOpen) {
+			clickedOpen.current = false;
 		}
 	}, [isOpen]);
 
@@ -75,16 +78,19 @@ export default function useDropdownMenu(itemCount: number) {
 		if (isKeyboardEvent(e)) {
 			const { key } = e;
 
-			if (key !== 'Tab' && key !== 'Shift') {
-				e.preventDefault();
+			if (!['Enter', ' ', 'Tab', 'ArrowDown'].includes(key)) {
+				return;
 			}
 
-			if (key === 'Enter' || key === ' ') {
+			if ((key === 'Tab' || key === 'ArrowDown') && clickedOpen.current && isOpen) {
+				e.preventDefault();
+				moveFocus(0);
+			} else if (key !== 'Tab') {
+				e.preventDefault();
 				setIsOpen(true);
-			} else if (key === 'Tab') {
-				setIsOpen(false);
 			}
 		} else {
+			clickedOpen.current = !isOpen;
 			setIsOpen(!isOpen);
 		}
 	};

--- a/src/use-dropdown-menu.ts
+++ b/src/use-dropdown-menu.ts
@@ -56,7 +56,7 @@ export default function useDropdownMenu(itemCount: number) {
 				}
 
 				// Ignore if we're clicking inside the menu
-				if (event.target.closest('[role="menu"]')) {
+				if (event.target.closest('[role="menu"]') instanceof Element) {
 					return;
 				}
 

--- a/test/puppeteer/demo.test.ts
+++ b/test/puppeteer/demo.test.ts
@@ -28,8 +28,16 @@ it('focuses on the first menu item when the enter key is pressed', async () => {
 	expect(await currentFocusID()).toBe('menu-item-1');
 });
 
-it('focuses on the menu button after pressing escape', async () => {
+it('leaves focus on the button if the button is clicked', async () => {
 	await page.click('#menu-button');
+	await menuOpen();
+
+	expect(await currentFocusID()).toBe('menu-button');
+});
+
+it('focuses on the menu button after pressing escape', async () => {
+	await page.focus('#menu-button');
+	await keyboard.down('Enter');
 	await menuOpen();
 
 	await keyboard.down('Escape');
@@ -39,7 +47,8 @@ it('focuses on the menu button after pressing escape', async () => {
 });
 
 it('focuses on the next item in the tab order after pressing tab', async () => {
-	await page.click('#menu-button');
+	await page.focus('#menu-button');
+	await keyboard.down('Enter');
 	await menuOpen();
 
 	await keyboard.down('Tab');
@@ -49,7 +58,8 @@ it('focuses on the next item in the tab order after pressing tab', async () => {
 });
 
 it('focuses on the previous item in the tab order after pressing shift-tab', async () => {
-	await page.click('#menu-button');
+	await page.focus('#menu-button');
+	await keyboard.down('Enter');
 	await menuOpen();
 
 	await keyboard.down('Shift');
@@ -60,7 +70,8 @@ it('focuses on the previous item in the tab order after pressing shift-tab', asy
 });
 
 it('closes the menu if you click outside of it', async () => {
-	await page.click('#menu-button');
+	await page.focus('#menu-button');
+	await keyboard.down('Enter');
 	await menuOpen();
 
 	await page.click('body');
@@ -70,7 +81,8 @@ it('closes the menu if you click outside of it', async () => {
 });
 
 it('leaves the menu open if you click inside of it', async () => {
-	await page.click('#menu-button');
+	await page.focus('#menu-button');
+	await keyboard.down('Enter');
 	await menuOpen();
 
 	await page.click('#menu-item-1');
@@ -87,7 +99,8 @@ it('leaves the menu open if you click inside of it', async () => {
 it('reroutes enter presses on menu items as clicks', async () => {
 	let alertAppeared = false;
 
-	await page.click('#menu-button');
+	await page.focus('#menu-button');
+	await keyboard.down('Enter');
 	await menuOpen();
 
 	// eslint-disable-next-line @typescript-eslint/no-misused-promises

--- a/test/puppeteer/demo.test.ts
+++ b/test/puppeteer/demo.test.ts
@@ -20,15 +20,7 @@ it('has the correct page title', async () => {
 	await expect(page.title()).resolves.toMatch('React Accessible Dropdown Menu Hook');
 });
 
-it('focuses on the first menu item when the enter key is pressed', async () => {
-	await page.focus('#menu-button');
-	await keyboard.down('Enter');
-	await menuOpen();
-
-	expect(await currentFocusID()).toBe('menu-item-1');
-});
-
-it('leaves focus on the button if the button is clicked', async () => {
+it('leaves focus on the button after clicking it', async () => {
 	await page.click('#menu-button');
 	await menuOpen();
 
@@ -74,7 +66,7 @@ it('closes the menu if you click outside of it', async () => {
 	await keyboard.down('Enter');
 	await menuOpen();
 
-	await page.click('body');
+	await page.click('h1');
 	await menuClosed(); // times out if menu doesn't close
 
 	expect(true).toBe(true);

--- a/test/use-dropdown-menu.test.tsx
+++ b/test/use-dropdown-menu.test.tsx
@@ -18,6 +18,36 @@ it('moves the focus to the first menu item after pressing enter while focused on
 	expect(document.activeElement?.id).toBe('menu-item-1');
 });
 
+it('moves the focus to the first menu item after pressing space while focused on the menu button', () => {
+	const component = mount(<TestComponent />);
+	const button = component.find('#menu-button');
+
+	button.getDOMNode<HTMLButtonElement>().focus();
+	button.simulate('keydown', { key: ' ' });
+
+	expect(document.activeElement?.id).toBe('menu-item-1');
+});
+
+it('moves the focus to the first menu item after clicking the menu to open it, then pressing tab while focused on the menu button', () => {
+	const component = mount(<TestComponent />);
+	const button = component.find('#menu-button');
+
+	button.simulate('click');
+	button.simulate('keydown', { key: 'Tab' });
+
+	expect(document.activeElement?.id).toBe('menu-item-1');
+});
+
+it('moves the focus to the first menu item after clicking the menu to open it, then pressing arrow down while focused on the menu button', () => {
+	const component = mount(<TestComponent />);
+	const button = component.find('#menu-button');
+
+	button.simulate('click');
+	button.simulate('keydown', { key: 'ArrowDown' });
+
+	expect(document.activeElement?.id).toBe('menu-item-1');
+});
+
 it('sets isOpen to true after pressing enter while focused on the menu button', () => {
 	const component = mount(<TestComponent />);
 	const button = component.find('#menu-button');
@@ -25,6 +55,17 @@ it('sets isOpen to true after pressing enter while focused on the menu button', 
 
 	button.getDOMNode<HTMLButtonElement>().focus();
 	button.simulate('keydown', { key: 'Enter' });
+
+	expect(span.text()).toBe('true');
+});
+
+it('sets isOpen to true after pressing space while focused on the menu button', () => {
+	const component = mount(<TestComponent />);
+	const button = component.find('#menu-button');
+	const span = component.find('#is-open-indicator');
+
+	button.getDOMNode<HTMLButtonElement>().focus();
+	button.simulate('keydown', { key: ' ' });
 
 	expect(span.text()).toBe('true');
 });


### PR DESCRIPTION
Currently, when a user clicks the button, the first menu item is automatically focused. This is recommended in the [WAI-ARIA Authoring Practices 1.1 section 3.15](https://www.w3.org/TR/wai-aria-practices/#menu):

> When a menu opens, or when a menubar receives focus, keyboard focus is placed on the first item.

Here's what that looks like:

![Screen Recording 2019-12-20 at 09 25 AM](https://user-images.githubusercontent.com/3850064/71265968-fed25b80-230c-11ea-8e8e-bf09139dfaf8.gif)

As shown in that screen recording, the first menu item has a blue ring around it. This can be both unsightly from a UI perspective, and confusing from a UX perspective, since most users using a mouse exclusively do not need the first menu item focused.

We wanted to learn how other companies tackled this problem, so we tested dropdown menus on prominent websites…

## Google

![Screen Recording 2019-12-20 at 09 24 AM](https://user-images.githubusercontent.com/3850064/71265993-114c9500-230d-11ea-9745-1b9d97339dfe.gif)

Clicking the button focuses the first item, but doesn't show the focus indicator until you press tab. This also happens whenever the user uses the enter key to open the dropdown menu, which oddly enough does not adhere to the WCAG Google helped write…

## Facebook

![Screen Recording 2019-12-20 at 09 27 AM](https://user-images.githubusercontent.com/3850064/71266130-5d97d500-230d-11ea-9363-8a086ebea3f7.gif)

The first time you activate the help dropdown, the dropdown shows a loading indicator and no element within the menu is focused. Focus is completely lost and it's very difficult to navigate back to the dropdown with a keyboard. Subsequent times you activate the dropdown, whether with mouse or keyboard, the "help center" link is focused, but no focus ring is visible until you start tabbing (even if you activated the dropdown originally with the keyboard).

## GitHub

![Screen Recording 2019-12-20 at 09 46 AM](https://user-images.githubusercontent.com/3850064/71266261-a8195180-230d-11ea-96c7-8349c936d370.gif)

Clicking the button does not focus the first item, but using the tab key or arrow down key on the button while the menu is open does move focus to the first item. Pressing enter on the button automatically focuses the first item.

## Twitter

![Screen Recording 2019-12-20 at 09 33 AM](https://user-images.githubusercontent.com/3850064/71266182-80c28480-230d-11ea-8b0f-7be1d10e85cb.gif)

Very similar to GitHub, although you cannot escape the dropdown via the tab key (just the escape key).

-----------

There's clearly a great deal of variance from company-to-company regarding how to design the behavior of dropdown menus. Realizing that this is the case, and that the WAI-ARIA Authoring Practices are more so recommendations rather than requirements, this PR proposes to introduce a slight deviation from the recommendations—albeit in a way that still meets the WCAG.

This PR makes it so **the dropdown menu's first item is only focused automatically when the keyboard is used to open it**. In effect, this means that if a user opens the menu with their mouse, no focus ring will be present on the first item.

If for some reason the user needs to begin using the keyboard after opening a menu with their mouse, they can either use the tab key or arrow down key to focus the first menu item.

Here's what that looks like:

![Screen Recording 2019-12-20 at 09 39 AM](https://user-images.githubusercontent.com/3850064/71266292-bbc4b800-230d-11ea-85ad-1c5cc01bd83d.gif)