### PR TITLE
Don't create deploy job for PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ jobs:
         on:
           tags: true
     - stage: deploy
-      if: branch = master
+      if: type = push AND branch = master
       name: Deploy to GitHub Pages
       node_js: lts/*
       script:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "react-accessible-dropdown-menu-hook",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "A simple Hook for creating fully accessible dropdown menus in React",
 	"main": "dist/use-dropdown-menu.js",
 	"types": "dist/use-dropdown-menu.d.ts",


### PR DESCRIPTION
This fixes an issue where the "Deploy to GitHub Pages" job was created for PRs. It didn't actually deploy, but it did slow down the CI pipeline.

This also bumps the version to `1.1.1`.