### PR TITLE
Expose way to programmatically close menu

### DIFF
--- a/demo/src/app.tsx
+++ b/demo/src/app.tsx
@@ -6,7 +6,7 @@ import useDropdownMenu from 'react-accessible-dropdown-menu-hook';
 // Functional component
 const App: React.FC = () => {
 	// Use the Hook
-	const {buttonProps, itemProps, isOpen} = useDropdownMenu(3);
+	const { buttonProps, itemProps, isOpen } = useDropdownMenu(3);
 
 	// Return JSX
 	return (

--- a/demo/src/app.tsx
+++ b/demo/src/app.tsx
@@ -6,7 +6,7 @@ import useDropdownMenu from 'react-accessible-dropdown-menu-hook';
 // Functional component
 const App: React.FC = () => {
 	// Use the Hook
-	const [buttonProps, itemProps, isOpen] = useDropdownMenu(3);
+	const {buttonProps, itemProps, isOpen} = useDropdownMenu(3);
 
 	// Return JSX
 	return (

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "react-accessible-dropdown-menu-hook",
-	"version": "1.1.1",
+	"version": "2.0.0",
 	"description": "A simple Hook for creating fully accessible dropdown menus in React",
 	"main": "dist/use-dropdown-menu.js",
 	"types": "dist/use-dropdown-menu.d.ts",

--- a/src/use-dropdown-menu.ts
+++ b/src/use-dropdown-menu.ts
@@ -85,7 +85,7 @@ export default function useDropdownMenu(itemCount: number) {
 	useEffect(() => {
 		// This function is designed to close the menu when an item is clicked
 		const handleItemClick = (event: MouseEvent) => {
-			if ((event.target as HTMLAnchorElement)?.href === undefined) {
+			if (!(event.target as HTMLAnchorElement)?.href) {
 				setIsOpen(false);
 			}
 		};

--- a/src/use-dropdown-menu.ts
+++ b/src/use-dropdown-menu.ts
@@ -174,5 +174,5 @@ export default function useDropdownMenu(itemCount: number) {
 	}));
 
 	// Return a listener for the button, individual list items, and the state of the menu
-	return {buttonProps, itemProps, isOpen, setIsOpen} as const;
+	return { buttonProps, itemProps, isOpen, setIsOpen } as const;
 }

--- a/src/use-dropdown-menu.ts
+++ b/src/use-dropdown-menu.ts
@@ -74,11 +74,29 @@ export default function useDropdownMenu(itemCount: number) {
 			}, 10);
 		};
 
+		// This function is designed to close the menu when an item is clicked
+		const handleItemClick = (event: MouseEvent) => {
+			if (!(event.target as HTMLAnchorElement)?.href) {
+				setIsOpen(false);
+			}
+		};
+
 		// Add listener
 		document.addEventListener('click', handleEveryClick);
 
-		// Return function to remove listener
-		return () => document.removeEventListener('click', handleEveryClick);
+		if (isOpen) {
+			// Add listener for each item
+			itemRefs.current?.forEach(ref => ref.current?.addEventListener('click', handleItemClick));
+		} else {
+			// Remove listener for each item
+			itemRefs.current?.forEach(ref => ref.current?.removeEventListener('click', handleItemClick));
+		}
+
+		// Return function to remove listeners
+		return () => {
+			document.removeEventListener('click', handleEveryClick);
+			itemRefs.current?.forEach(ref => ref.current?.removeEventListener('click', handleItemClick));
+		};
 	}, [isOpen]);
 
 	// Create a handler function for the button's clicks and keyboard events

--- a/src/use-dropdown-menu.ts
+++ b/src/use-dropdown-menu.ts
@@ -81,28 +81,6 @@ export default function useDropdownMenu(itemCount: number) {
 		return () => document.removeEventListener('click', handleEveryClick);
 	}, [isOpen]);
 
-	// Handle listening for item clicks and closing the menu
-	useEffect(() => {
-		// This function is designed to close the menu when an item is clicked
-		const handleItemClick = (event: MouseEvent) => {
-			if (!(event.target as HTMLAnchorElement)?.href) {
-				setIsOpen(false);
-			}
-		};
-
-		// Add/remove listener based on whether the menu is open
-		if (isOpen) {
-			// Add listener for each item
-			itemRefs.current?.forEach(ref => ref.current?.addEventListener('click', handleItemClick));
-		} else {
-			// Remove listener for each item
-			itemRefs.current?.forEach(ref => ref.current?.removeEventListener('click', handleItemClick));
-		}
-
-		// Return function to remove listeners
-		return () => itemRefs.current?.forEach(ref => ref.current?.removeEventListener('click', handleItemClick));
-	}, [isOpen]);
-
 	// Create a handler function for the button's clicks and keyboard events
 	const buttonListener = (e: React.KeyboardEvent | React.MouseEvent) => {
 		// Detect if event was a keyboard event or a mouse event
@@ -196,5 +174,5 @@ export default function useDropdownMenu(itemCount: number) {
 	}));
 
 	// Return a listener for the button, individual list items, and the state of the menu
-	return [buttonProps, itemProps, isOpen] as const;
+	return {buttonProps, itemProps, isOpen, setIsOpen} as const;
 }

--- a/src/use-dropdown-menu.ts
+++ b/src/use-dropdown-menu.ts
@@ -90,6 +90,7 @@ export default function useDropdownMenu(itemCount: number) {
 			}
 		};
 
+		// Add/remove listener based on whether the menu is open
 		if (isOpen) {
 			// Add listener for each item
 			itemRefs.current?.forEach(ref => ref.current?.addEventListener('click', handleItemClick));

--- a/src/use-dropdown-menu.ts
+++ b/src/use-dropdown-menu.ts
@@ -74,15 +74,21 @@ export default function useDropdownMenu(itemCount: number) {
 			}, 10);
 		};
 
+		// Add listener
+		document.addEventListener('click', handleEveryClick);
+
+		// Return function to remove listener
+		return () => document.removeEventListener('click', handleEveryClick);
+	}, [isOpen]);
+
+	// Handle listening for item clicks and closing the menu
+	useEffect(() => {
 		// This function is designed to close the menu when an item is clicked
 		const handleItemClick = (event: MouseEvent) => {
-			if (!(event.target as HTMLAnchorElement)?.href) {
+			if ((event.target as HTMLAnchorElement)?.href === undefined) {
 				setIsOpen(false);
 			}
 		};
-
-		// Add listener
-		document.addEventListener('click', handleEveryClick);
 
 		if (isOpen) {
 			// Add listener for each item
@@ -93,10 +99,7 @@ export default function useDropdownMenu(itemCount: number) {
 		}
 
 		// Return function to remove listeners
-		return () => {
-			document.removeEventListener('click', handleEveryClick);
-			itemRefs.current?.forEach(ref => ref.current?.removeEventListener('click', handleItemClick));
-		};
+		return () => itemRefs.current?.forEach(ref => ref.current?.removeEventListener('click', handleItemClick));
 	}, [isOpen]);
 
 	// Create a handler function for the button's clicks and keyboard events

--- a/test/puppeteer/demo.test.ts
+++ b/test/puppeteer/demo.test.ts
@@ -72,6 +72,23 @@ it('closes the menu if you click outside of it', async () => {
 	expect(true).toBe(true);
 });
 
+it('closes the menu if you click a menu item with a click handler', async () => {
+	await page.focus('#menu-button');
+	await keyboard.down('Enter');
+	await menuOpen();
+
+	// eslint-disable-next-line @typescript-eslint/no-misused-promises
+	page.once('dialog', async dialog => {
+		await dialog.dismiss();
+	});
+
+	await page.focus('#menu-item-3');
+	await keyboard.down('Enter');
+	await menuClosed(); // times out if menu doesn't close
+
+	expect(true).toBe(true);
+});
+
 it('leaves the menu open if you click inside of it', async () => {
 	await page.focus('#menu-button');
 	await keyboard.down('Enter');
@@ -96,7 +113,7 @@ it('reroutes enter presses on menu items as clicks', async () => {
 	await menuOpen();
 
 	// eslint-disable-next-line @typescript-eslint/no-misused-promises
-	page.on('dialog', async dialog => {
+	page.once('dialog', async dialog => {
 		alertAppeared = true;
 		await dialog.dismiss();
 	});

--- a/test/puppeteer/demo.test.ts
+++ b/test/puppeteer/demo.test.ts
@@ -82,8 +82,7 @@ it('closes the menu if you click a menu item with a click handler', async () => 
 		await dialog.dismiss();
 	});
 
-	await page.focus('#menu-item-3');
-	await keyboard.down('Enter');
+	await page.click('#menu-item-3');
 	await menuClosed(); // times out if menu doesn't close
 
 	expect(true).toBe(true);

--- a/test/puppeteer/demo.test.ts
+++ b/test/puppeteer/demo.test.ts
@@ -72,22 +72,6 @@ it('closes the menu if you click outside of it', async () => {
 	expect(true).toBe(true);
 });
 
-it('closes the menu if you click a menu item with a click handler', async () => {
-	await page.focus('#menu-button');
-	await keyboard.down('Enter');
-	await menuOpen();
-
-	// eslint-disable-next-line @typescript-eslint/no-misused-promises
-	page.once('dialog', async dialog => {
-		await dialog.dismiss();
-	});
-
-	await page.click('#menu-item-3');
-	await menuClosed(); // times out if menu doesn't close
-
-	expect(true).toBe(true);
-});
-
 it('leaves the menu open if you click inside of it', async () => {
 	await page.focus('#menu-button');
 	await keyboard.down('Enter');

--- a/test/test-component.tsx
+++ b/test/test-component.tsx
@@ -4,7 +4,7 @@ import useDropdownMenu from '../src/use-dropdown-menu';
 
 // A mock component for testing the Hook
 const TestComponent: React.FC = () => {
-	const [buttonProps, itemProps, isOpen] = useDropdownMenu(3);
+	const { buttonProps, itemProps, isOpen } = useDropdownMenu(3);
 
 	return (
 		<React.Fragment>

--- a/test/test-component.tsx
+++ b/test/test-component.tsx
@@ -4,7 +4,7 @@ import useDropdownMenu from '../src/use-dropdown-menu';
 
 // A mock component for testing the Hook
 const TestComponent: React.FC = () => {
-	const { buttonProps, itemProps, isOpen } = useDropdownMenu(3);
+	const { buttonProps, itemProps, isOpen, setIsOpen } = useDropdownMenu(3);
 
 	return (
 		<React.Fragment>
@@ -13,7 +13,7 @@ const TestComponent: React.FC = () => {
 			</button>
 
 			<div role='menu' id='menu'>
-				<a {...itemProps[0]} onClick={() => null} id='menu-item-1'>
+				<a {...itemProps[0]} onClick={() => setIsOpen(false)} id='menu-item-1'>
 					Item 1
 				</a>
 

--- a/test/use-dropdown-menu.test.tsx
+++ b/test/use-dropdown-menu.test.tsx
@@ -70,6 +70,20 @@ it('sets isOpen to true after pressing space while focused on the menu button', 
 	expect(span.text()).toBe('true');
 });
 
+it('sets isOpen to false after clicking a menu item that calls the state change function', () => {
+	const component = mount(<TestComponent />);
+	const button = component.find('#menu-button');
+	const itemWithHandler = component.find('#menu-item-1');
+	const span = component.find('#is-open-indicator');
+
+	button.getDOMNode<HTMLButtonElement>().focus();
+	button.simulate('keydown', { key: 'Enter' });
+
+	itemWithHandler.simulate('click');
+
+	expect(span.text()).toBe('false');
+});
+
 it('moves the focus to the next element in the menu after pressing the down arrow', () => {
 	const component = mount(<TestComponent />);
 	const button = component.find('#menu-button');


### PR DESCRIPTION
Currently when a menu item is clicked, by default the menu stays open. This behavior is not standard to most menus and should be reserved for when the user indicates they would like the menu to stay open.

This PR makes it so that when an item is clicked, if it is not a link it closes the menu.

closes #70 