### PR TITLE
fix: allow dynamic item count

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,6 +24,7 @@
 		"@typescript-eslint/no-unused-vars": "error",
 		"eqeqeq": ["error"],
 		"prefer-template": ["error"],
+		"react/prop-types": "off",
 		"padding-line-between-statements": [
 			"error",
 			{

--- a/src/use-dropdown-menu.ts
+++ b/src/use-dropdown-menu.ts
@@ -20,7 +20,8 @@ export default function useDropdownMenu(itemCount: number) {
 
 	// Create refs
 	const buttonRef = useRef<HTMLButtonElement>(null);
-	const itemRefs = useRef([...Array(itemCount)].map(() => createRef<HTMLAnchorElement>()));
+
+	const itemRefs = useRef<React.RefObject<HTMLAnchorElement>[]>([]);
 
 	// Create type guard
 	const isKeyboardEvent = (e: React.KeyboardEvent | React.MouseEvent): e is React.KeyboardEvent =>
@@ -31,6 +32,11 @@ export default function useDropdownMenu(itemCount: number) {
 		currentFocusIndex.current = itemIndex;
 		itemRefs.current[itemIndex].current?.focus();
 	};
+
+	// Initialize refs an update them on prop changes
+	useEffect(() => {
+		itemRefs.current = [...Array(itemCount)].map(() => createRef<HTMLAnchorElement>());
+	}, [itemCount]);
 
 	// Focus the first item when the menu opens
 	useEffect(() => {

--- a/test/props.test.tsx
+++ b/test/props.test.tsx
@@ -1,0 +1,31 @@
+// Imports
+import React from 'react';
+import { mount } from 'enzyme';
+import TestPropsComponent from './test-props-component';
+
+// Tests
+it('renders', () => {
+	mount(<TestPropsComponent childCount={2} />);
+});
+
+it('wraps the focus to the uniq element', () => {
+	const component = mount(<TestPropsComponent childCount={1} />);
+	const button = component.find('#menu-button');
+
+	button.simulate('click');
+	button.simulate('keydown', { key: 'ArrowDown' });
+	expect(document.activeElement?.id).toBe('menu-item-0');
+});
+
+it('moves the focus to the next element, even it it has been added later', () => {
+	const component = mount(<TestPropsComponent childCount={1} />);
+	const button = component.find('#menu-button');
+
+	component.setProps({ childCount: 2 });
+	component.update();
+	button.simulate('click');
+	expect(document.activeElement?.id).toBe('menu-item-0');
+
+	button.simulate('keydown', { key: 'ArrowDown' });
+	expect(document.activeElement?.id).toBe('menu-item-1');
+});

--- a/test/test-props-component.tsx
+++ b/test/test-props-component.tsx
@@ -1,0 +1,28 @@
+// Imports
+import React from 'react';
+import useDropdownMenu from '../src/use-dropdown-menu';
+
+// A mock component for testing the Hook
+const TestPropsComponent: React.FC<{ childCount: number }> = ({ childCount }) => {
+	const { buttonProps, itemProps } = useDropdownMenu(childCount);
+
+	return (
+		<React.Fragment>
+			<button {...buttonProps} id='menu-button'>
+				Primary
+			</button>
+
+			<div role='menu' id='menu'>
+				{[
+					...Array.from(Array(childCount)).map((_, index) => (
+						<a key={index} {...itemProps[index]} id={`menu-item-${index}`}>
+							Item {index}
+						</a>
+					)),
+				]}
+			</div>
+		</React.Fragment>
+	);
+};
+
+export default TestPropsComponent;


### PR DESCRIPTION
# What

Add a `useEffect` hook that populate items refs.

# Why

It allows dynamic item count

use case

```tsx
const MyCompontent = () => {
  const [items, setItems] = useState(['1', '2'])
  const { buttonProps, itemProps, isOpen, setIsOpen } = useDropdownMenu(items.length)
  setTimeout(() => {
    setItems([...items, '3'])
  }, 3000)

  return (
    <ul>
      {items.map((item, index) => (
        <li key={item} {...itemProps[index]}>
          <a>{item}</a>
        </li>
      ))}
    </ul>
  )
}
```
