### PR TITLE
Bump minor version and update homepage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "react-accessible-dropdown-menu-hook",
-	"version": "2.0.1",
+	"version": "2.1.0",
 	"description": "A simple Hook for creating fully accessible dropdown menus in React",
 	"main": "dist/use-dropdown-menu.js",
 	"types": "dist/use-dropdown-menu.d.ts",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 	"bugs": {
 		"url": "https://github.com/sparksuite/react-accessible-dropdown-menu-hook/issues"
 	},
-	"homepage": "https://github.com/sparksuite/react-accessible-dropdown-menu-hook",
+	"homepage": "https://sparksuite.github.io/react-accessible-dropdown-menu-hook/",
 	"dependencies": {},
 	"peerDependencies": {
 		"react": ">=16.8",


### PR DESCRIPTION
This bumps the minor version to 2.1.0 and updates the homepage URL.