### PR TITLE
Reset page between tests

### DIFF
--- a/test/puppeteer/demo.test.ts
+++ b/test/puppeteer/demo.test.ts
@@ -1,9 +1,6 @@
 // Imports
 import path from 'path';
 
-// Destructured constant for readability
-const { keyboard } = page;
-
 // Helper functions used in multiple tests
 const currentFocusID = () => page.evaluate(() => document.activeElement.id);
 const menuOpen = () => page.waitForSelector('#menu', { visible: true });
@@ -11,6 +8,8 @@ const menuClosed = () => page.waitForSelector('#menu', { hidden: true });
 
 // Tests
 beforeEach(async () => {
+	await jestPuppeteer.resetPage();
+
 	await page.goto(`file://${path.join(__dirname, '..', '..', 'demo', 'build', 'index.html')}`, {
 		waitUntil: 'load',
 	});
@@ -29,10 +28,10 @@ it('leaves focus on the button after clicking it', async () => {
 
 it('focuses on the menu button after pressing escape', async () => {
 	await page.focus('#menu-button');
-	await keyboard.down('Enter');
+	await page.keyboard.down('Enter');
 	await menuOpen();
 
-	await keyboard.down('Escape');
+	await page.keyboard.down('Escape');
 	await menuClosed();
 
 	expect(await currentFocusID()).toBe('menu-button');
@@ -40,10 +39,10 @@ it('focuses on the menu button after pressing escape', async () => {
 
 it('focuses on the next item in the tab order after pressing tab', async () => {
 	await page.focus('#menu-button');
-	await keyboard.down('Enter');
+	await page.keyboard.down('Enter');
 	await menuOpen();
 
-	await keyboard.down('Tab');
+	await page.keyboard.down('Tab');
 	await menuClosed();
 
 	expect(await currentFocusID()).toBe('first-footer-link');
@@ -51,11 +50,11 @@ it('focuses on the next item in the tab order after pressing tab', async () => {
 
 it('focuses on the previous item in the tab order after pressing shift-tab', async () => {
 	await page.focus('#menu-button');
-	await keyboard.down('Enter');
+	await page.keyboard.down('Enter');
 	await menuOpen();
 
-	await keyboard.down('Shift');
-	await keyboard.down('Tab');
+	await page.keyboard.down('Shift');
+	await page.keyboard.down('Tab');
 	await menuClosed();
 
 	expect(await currentFocusID()).toBe('menu-button');
@@ -63,7 +62,7 @@ it('focuses on the previous item in the tab order after pressing shift-tab', asy
 
 it('closes the menu if you click outside of it', async () => {
 	await page.focus('#menu-button');
-	await keyboard.down('Enter');
+	await page.keyboard.down('Enter');
 	await menuOpen();
 
 	await page.click('h1');
@@ -74,7 +73,7 @@ it('closes the menu if you click outside of it', async () => {
 
 it('leaves the menu open if you click inside of it', async () => {
 	await page.focus('#menu-button');
-	await keyboard.down('Enter');
+	await page.keyboard.down('Enter');
 	await menuOpen();
 
 	await page.click('#menu-item-1');
@@ -92,7 +91,7 @@ it('reroutes enter presses on menu items as clicks', async () => {
 	let alertAppeared = false;
 
 	await page.focus('#menu-button');
-	await keyboard.down('Enter');
+	await page.keyboard.down('Enter');
 	await menuOpen();
 
 	// eslint-disable-next-line @typescript-eslint/no-misused-promises
@@ -102,7 +101,7 @@ it('reroutes enter presses on menu items as clicks', async () => {
 	});
 
 	await page.focus('#menu-item-3');
-	await keyboard.down('Enter');
+	await page.keyboard.down('Enter');
 
 	expect(alertAppeared).toBe(true);
 });

--- a/test/puppeteer/demo.test.ts
+++ b/test/puppeteer/demo.test.ts
@@ -76,11 +76,21 @@ it('leaves the menu open if you click inside of it', async () => {
 	await page.keyboard.down('Enter');
 	await menuOpen();
 
-	await page.click('#menu-item-1');
+	// eslint-disable-next-line @typescript-eslint/no-misused-promises
+	page.once('dialog', async (dialog) => {
+		await dialog.dismiss();
+	});
+
+	await page.click('#menu-item-3');
 	await new Promise((resolve) => setTimeout(resolve, 1000)); // visibility: hidden is delayed via CSS
 	await menuOpen(); // times out if menu closes
 
-	await page.click('#menu');
+	const { xOffset, yOffset } = await page.evaluate((el: HTMLElement) => {
+		const { left: xOffset, top: yOffset } = el.getBoundingClientRect();
+		return { xOffset, yOffset };
+	}, await page.$('#menu'));
+
+	await page.mouse.click(xOffset + 2, yOffset + 2); // Click just inside the top left corner (`page.click()` clicks the center, which is a link to NPM)
 	await new Promise((resolve) => setTimeout(resolve, 1000)); // visibility: hidden is delayed via CSS
 	await menuOpen(); // times out if menu closes
 


### PR DESCRIPTION
This PR resets Puppeteer pages between tests, which means each test operates with a completely clean slate. It was discovered that previously, page state was impacted by the effects of prior tests, which is both confusing and led to tests that didn't function as intended.

This also fixes a test that actually wasn't working all along, but resetting the page brought to light.

I also did a little refactoring to make some of the test designs more clear.