### PR TITLE
Fix linking issue from earlier

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -22,7 +22,7 @@
 		"@mdx-js/react": "^1.6.21",
 		"clsx": "^1.1.1",
 		"react": "^17.0.2",
-		"react-accessible-dropdown-menu-hook": "^2.2.0",
+		"react-accessible-dropdown-menu-hook": "link:../",
 		"react-dom": "^17.0.2"
 	},
 	"browserslist": {

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -8024,10 +8024,9 @@ rc@^1.2.8:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-accessible-dropdown-menu-hook@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/react-accessible-dropdown-menu-hook/-/react-accessible-dropdown-menu-hook-2.2.0.tgz#0b54fafcd9248df4e7cf6e0fe997ae72fc8059e1"
-  integrity sha512-2lZUFcm1SBdJ/qiyTtcaNn07w4gVPL4VcI7dw/DoKAz8MZW3TUcRBwyhaAkuKJmdlxX4A4L9S26k2wmjdylzlQ==
+"react-accessible-dropdown-menu-hook@link:..":
+  version "0.0.0"
+  uid ""
 
 react-base16-styling@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
Earlier, I committed a change that fixed a problem incorrectly. The problem was not that the `website/` directory used the parent directory, the problem was that it referenced it the wrong way. It should have referenced it as `link:../` and not just `../`.