### PR TITLE
Improve testing coverage

### DIFF
--- a/src/use-dropdown-menu.test.tsx
+++ b/src/use-dropdown-menu.test.tsx
@@ -381,3 +381,41 @@ it('Can navigate to a dynamically-added item', () => {
 
 	expect(screen.getByText('Item 4')).toHaveFocus();
 });
+
+it('Ignores keys that buttons don’t need to handle', () => {
+	render(<TestComponent />);
+
+	userEvent.tab();
+
+	userEvent.type(screen.getByText('Primary'), 'Z', {
+		skipClick: true,
+	});
+});
+
+it('Ignores keys that items don’t need to handle', () => {
+	render(<TestComponent />);
+
+	userEvent.tab();
+
+	userEvent.type(screen.getByText('Primary'), '{enter}', {
+		skipClick: true,
+	});
+
+	userEvent.type(screen.getByText('Item 1'), 'Z', {
+		skipClick: true,
+	});
+});
+
+it('Doesn’t crash when enter press occurs on a menu item', () => {
+	render(<TestComponent />);
+
+	userEvent.tab();
+
+	userEvent.type(screen.getByText('Primary'), '{enter}', {
+		skipClick: true,
+	});
+
+	userEvent.type(screen.getByText('Item 1'), '{enter}', {
+		skipClick: true,
+	});
+});


### PR DESCRIPTION
This PR aims to improve the coverage percentage as much as possible. It looks like it's still only possible to test the clicking outside of the menu in a real, headless browser, but that's the only part that's uncovered by Jest's test suite.