### PR TITLE
Resolve the same version of @types/react for all dependencies in test project

### DIFF
--- a/test-projects/browser/package.json
+++ b/test-projects/browser/package.json
@@ -21,6 +21,9 @@
 		"ts-node": "^9.1.1",
 		"typescript": "^4.1.2"
 	},
+	"resolutions": {
+		"@types/react": "link:../../node_modules/@types/react"
+	},
 	"browserslist": {
 		"production": [
 			">0.2%",

--- a/test-projects/browser/package.json
+++ b/test-projects/browser/package.json
@@ -22,7 +22,11 @@
 		"typescript": "^4.1.2"
 	},
 	"resolutions": {
-		"@types/react": "link:../../node_modules/@types/react"
+		"@types/react": "link:../../node_modules/@types/react",
+		"@types/react-dom": "link:../../node_modules/@types/react-dom",
+		"react": "link:../../node_modules/react",
+		"react-accessible-dropdown-menu-hook": "link:../..",
+		"react-dom": "link:../../node_modules/react-dom"
 	},
 	"browserslist": {
 		"production": [


### PR DESCRIPTION
This pull request adds a resolution object to the `package.json` to ensure anything that depends on `@types/react` resolves the same version.

Closes #270 