### PR TITLE
Implement extra keyboard controls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "react-accessible-dropdown-menu-hook",
-	"version": "2.2.2",
+	"version": "2.3.2",
 	"description": "A simple Hook for creating fully accessible dropdown menus in React",
 	"main": "dist/use-dropdown-menu.js",
 	"types": "dist/use-dropdown-menu.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "react-accessible-dropdown-menu-hook",
-	"version": "2.3.2",
+	"version": "2.3.0",
 	"description": "A simple Hook for creating fully accessible dropdown menus in React",
 	"main": "dist/use-dropdown-menu.js",
 	"types": "dist/use-dropdown-menu.d.ts",

--- a/src/use-dropdown-menu.test.tsx
+++ b/src/use-dropdown-menu.test.tsx
@@ -26,7 +26,7 @@ const TestComponent: React.FC = () => {
 						onClick={clickHandlers[i]}
 						href={i > 1 ? 'https://example.com' : undefined}
 					>
-						Item {i + 1}
+						{i + 1} Item
 					</a>
 				))}
 			</div>
@@ -62,7 +62,7 @@ it('Moves the focus to the first menu item after pressing enter while focused on
 		skipClick: true,
 	});
 
-	expect(screen.getByText('Item 1')).toHaveFocus();
+	expect(screen.getByText('1 Item')).toHaveFocus();
 });
 
 it('Moves the focus to the first menu item after pressing space while focused on the menu button', () => {
@@ -76,7 +76,7 @@ it('Moves the focus to the first menu item after pressing space while focused on
 		skipClick: true,
 	});
 
-	expect(screen.getByText('Item 1')).toHaveFocus();
+	expect(screen.getByText('1 Item')).toHaveFocus();
 });
 
 it('Moves the focus to the first menu item after clicking the menu to open it, then pressing tab while focused on the menu button', () => {
@@ -88,7 +88,7 @@ it('Moves the focus to the first menu item after clicking the menu to open it, t
 
 	userEvent.tab();
 
-	expect(screen.getByText('Item 1')).toHaveFocus();
+	expect(screen.getByText('1 Item')).toHaveFocus();
 });
 
 it('Moves the focus to the first menu item after clicking the menu to open it, then pressing arrow down while focused on the menu button', () => {
@@ -107,7 +107,7 @@ it('Moves the focus to the first menu item after clicking the menu to open it, t
 		})
 	);
 
-	expect(screen.getByText('Item 1')).toHaveFocus();
+	expect(screen.getByText('1 Item')).toHaveFocus();
 });
 
 it('Sets isOpen to true after pressing enter while focused on the menu button', () => {
@@ -146,7 +146,7 @@ it('Sets isOpen to false after clicking a menu item that calls the state change 
 	render(<TestComponent />);
 
 	userEvent.click(screen.getByText('Primary'));
-	userEvent.click(screen.getByText('Item 2'));
+	userEvent.click(screen.getByText('2 Item'));
 
 	expect(screen.getByTestId('is-open-indicator')).toHaveTextContent('false');
 });
@@ -160,10 +160,10 @@ it('Moves the focus to the next element in the menu after pressing the down arro
 		skipClick: true,
 	});
 
-	expect(screen.getByText('Item 1')).toHaveFocus();
+	expect(screen.getByText('1 Item')).toHaveFocus();
 
 	fireEvent(
-		screen.getByText('Item 1'),
+		screen.getByText('1 Item'),
 		new KeyboardEvent('keydown', {
 			key: 'ArrowDown',
 			bubbles: true,
@@ -171,7 +171,7 @@ it('Moves the focus to the next element in the menu after pressing the down arro
 		})
 	);
 
-	expect(screen.getByText('Item 2')).toHaveFocus();
+	expect(screen.getByText('2 Item')).toHaveFocus();
 });
 
 it('Moves the focus to the previous element in the menu after pressing the up arrow', () => {
@@ -183,10 +183,10 @@ it('Moves the focus to the previous element in the menu after pressing the up ar
 		skipClick: true,
 	});
 
-	expect(screen.getByText('Item 1')).toHaveFocus();
+	expect(screen.getByText('1 Item')).toHaveFocus();
 
 	fireEvent(
-		screen.getByText('Item 1'),
+		screen.getByText('1 Item'),
 		new KeyboardEvent('keydown', {
 			key: 'ArrowDown',
 			bubbles: true,
@@ -194,10 +194,10 @@ it('Moves the focus to the previous element in the menu after pressing the up ar
 		})
 	);
 
-	expect(screen.getByText('Item 2')).toHaveFocus();
+	expect(screen.getByText('2 Item')).toHaveFocus();
 
 	fireEvent(
-		screen.getByText('Item 2'),
+		screen.getByText('2 Item'),
 		new KeyboardEvent('keydown', {
 			key: 'ArrowUp',
 			bubbles: true,
@@ -205,7 +205,7 @@ it('Moves the focus to the previous element in the menu after pressing the up ar
 		})
 	);
 
-	expect(screen.getByText('Item 1')).toHaveFocus();
+	expect(screen.getByText('1 Item')).toHaveFocus();
 });
 
 it('Wraps the focus to the last element when pressing the up arrow at the beginning of the menu', () => {
@@ -217,10 +217,10 @@ it('Wraps the focus to the last element when pressing the up arrow at the beginn
 		skipClick: true,
 	});
 
-	expect(screen.getByText('Item 1')).toHaveFocus();
+	expect(screen.getByText('1 Item')).toHaveFocus();
 
 	fireEvent(
-		screen.getByText('Item 1'),
+		screen.getByText('1 Item'),
 		new KeyboardEvent('keydown', {
 			key: 'ArrowUp',
 			bubbles: true,
@@ -228,7 +228,7 @@ it('Wraps the focus to the last element when pressing the up arrow at the beginn
 		})
 	);
 
-	expect(screen.getByText('Item 4')).toHaveFocus();
+	expect(screen.getByText('4 Item')).toHaveFocus();
 });
 
 it('Wraps the focus to the first element when pressing the down arrow at the end of the menu', () => {
@@ -240,10 +240,10 @@ it('Wraps the focus to the first element when pressing the down arrow at the end
 		skipClick: true,
 	});
 
-	expect(screen.getByText('Item 1')).toHaveFocus();
+	expect(screen.getByText('1 Item')).toHaveFocus();
 
 	fireEvent(
-		screen.getByText('Item 1'),
+		screen.getByText('1 Item'),
 		new KeyboardEvent('keydown', {
 			key: 'ArrowUp',
 			bubbles: true,
@@ -251,10 +251,10 @@ it('Wraps the focus to the first element when pressing the down arrow at the end
 		})
 	);
 
-	expect(screen.getByText('Item 4')).toHaveFocus();
+	expect(screen.getByText('4 Item')).toHaveFocus();
 
 	fireEvent(
-		screen.getByText('Item 4'),
+		screen.getByText('4 Item'),
 		new KeyboardEvent('keydown', {
 			key: 'ArrowDown',
 			bubbles: true,
@@ -262,7 +262,7 @@ it('Wraps the focus to the first element when pressing the down arrow at the end
 		})
 	);
 
-	expect(screen.getByText('Item 1')).toHaveFocus();
+	expect(screen.getByText('1 Item')).toHaveFocus();
 });
 
 it('Sets isOpen to false after pressing escape while focused on a menu item', () => {
@@ -274,7 +274,7 @@ it('Sets isOpen to false after pressing escape while focused on a menu item', ()
 		skipClick: true,
 	});
 
-	userEvent.type(screen.getByText('Item 1'), '{esc}', {
+	userEvent.type(screen.getByText('1 Item'), '{esc}', {
 		skipClick: true,
 	});
 
@@ -304,7 +304,7 @@ it('Moves the focus to the menu button after pressing escape while focused on a 
 		skipClick: true,
 	});
 
-	userEvent.type(screen.getByText('Item 1'), '{esc}', {
+	userEvent.type(screen.getByText('1 Item'), '{esc}', {
 		skipClick: true,
 	});
 
@@ -335,7 +335,7 @@ it('Adds properties to items added after mount', () => {
 
 	userEvent.click(screen.getByText('Add Item'));
 
-	expect(screen.getByText('Item 4')).toHaveAttribute('role', 'menuitem');
+	expect(screen.getByText('4 Item')).toHaveAttribute('role', 'menuitem');
 });
 
 it('Can navigate to a dynamically-added item', () => {
@@ -355,7 +355,7 @@ it('Can navigate to a dynamically-added item', () => {
 	);
 
 	fireEvent(
-		screen.getByText('Item 1'),
+		screen.getByText('1 Item'),
 		new KeyboardEvent('keydown', {
 			key: 'ArrowDown',
 			bubbles: true,
@@ -364,7 +364,7 @@ it('Can navigate to a dynamically-added item', () => {
 	);
 
 	fireEvent(
-		screen.getByText('Item 2'),
+		screen.getByText('2 Item'),
 		new KeyboardEvent('keydown', {
 			key: 'ArrowDown',
 			bubbles: true,
@@ -373,7 +373,7 @@ it('Can navigate to a dynamically-added item', () => {
 	);
 
 	fireEvent(
-		screen.getByText('Item 3'),
+		screen.getByText('3 Item'),
 		new KeyboardEvent('keydown', {
 			key: 'ArrowDown',
 			bubbles: true,
@@ -382,7 +382,7 @@ it('Can navigate to a dynamically-added item', () => {
 	);
 
 	fireEvent(
-		screen.getByText('Item 4'),
+		screen.getByText('4 Item'),
 		new KeyboardEvent('keydown', {
 			key: 'ArrowDown',
 			bubbles: true,
@@ -390,7 +390,7 @@ it('Can navigate to a dynamically-added item', () => {
 		})
 	);
 
-	expect(screen.getByText('Item 5')).toHaveFocus();
+	expect(screen.getByText('5 Item')).toHaveFocus();
 });
 
 it('Ignores keys that buttons don’t need to handle', () => {
@@ -412,9 +412,11 @@ it('Ignores keys that items don’t need to handle', () => {
 		skipClick: true,
 	});
 
-	userEvent.type(screen.getByText('Item 1'), 'Z', {
+	userEvent.type(screen.getByText('1 Item'), 'Z', {
 		skipClick: true,
 	});
+
+	expect(screen.getByText('1 Item')).toHaveFocus();
 });
 
 it('Doesn’t crash when enter press occurs on a menu item', () => {
@@ -426,7 +428,7 @@ it('Doesn’t crash when enter press occurs on a menu item', () => {
 		skipClick: true,
 	});
 
-	userEvent.type(screen.getByText('Item 1'), '{enter}', {
+	userEvent.type(screen.getByText('1 Item'), '{enter}', {
 		skipClick: true,
 	});
 });
@@ -440,7 +442,7 @@ it('Closes the menu after pressing enter on a menu item with a click handler', (
 		skipClick: true,
 	});
 
-	userEvent.type(screen.getByText('Item 1'), '{enter}', {
+	userEvent.type(screen.getByText('1 Item'), '{enter}', {
 		skipClick: true,
 	});
 
@@ -458,7 +460,7 @@ it('Activates the click handler of a menu item after pressing enter while focuse
 		skipClick: true,
 	});
 
-	userEvent.type(screen.getByText('Item 1'), '{enter}', {
+	userEvent.type(screen.getByText('1 Item'), '{enter}', {
 		skipClick: true,
 	});
 
@@ -474,7 +476,7 @@ it('Closes the menu after pressing space on a menu item with a click handler', (
 		skipClick: true,
 	});
 
-	userEvent.type(screen.getByText('Item 1'), '{space}', {
+	userEvent.type(screen.getByText('1 Item'), '{space}', {
 		skipClick: true,
 	});
 
@@ -492,9 +494,25 @@ it('Activates the click handler of a menu item after pressing space while focuse
 		skipClick: true,
 	});
 
-	userEvent.type(screen.getByText('Item 1'), '{space}', {
+	userEvent.type(screen.getByText('1 Item'), '{space}', {
 		skipClick: true,
 	});
 
 	expect(console.log).toHaveBeenCalledWith('Item one clicked');
+});
+
+it('Moves the focus to the menu item with a label that starts with the corresponding character that was pressed', () => {
+	render(<TestComponent />);
+
+	userEvent.tab();
+
+	userEvent.type(screen.getByText('Primary'), '{enter}', {
+		skipClick: true,
+	});
+
+	userEvent.type(screen.getByText('1 Item'), '3', {
+		skipClick: true,
+	});
+
+	expect(screen.getByText('3 Item')).toHaveFocus();
 });

--- a/src/use-dropdown-menu.test.tsx
+++ b/src/use-dropdown-menu.test.tsx
@@ -465,6 +465,22 @@ it('Activates the click handler of a menu item after pressing enter while focuse
 	expect(console.log).toHaveBeenCalledWith('Item one clicked');
 });
 
+it('Closes the menu after pressing space on a menu item with a click handler', () => {
+	render(<TestComponent />);
+
+	userEvent.tab();
+
+	userEvent.type(screen.getByText('Primary'), '{enter}', {
+		skipClick: true,
+	});
+
+	userEvent.type(screen.getByText('Item 1'), '{space}', {
+		skipClick: true,
+	});
+
+	expect(screen.getByTestId('is-open-indicator')).toHaveTextContent('false');
+});
+
 it('Activates the click handler of a menu item after pressing space while focused on it', () => {
 	render(<TestComponent />);
 

--- a/src/use-dropdown-menu.test.tsx
+++ b/src/use-dropdown-menu.test.tsx
@@ -464,3 +464,21 @@ it('Activates the click handler of a menu item after pressing enter while focuse
 
 	expect(console.log).toHaveBeenCalledWith('Item one clicked');
 });
+
+it('Activates the click handler of a menu item after pressing space while focused on it', () => {
+	render(<TestComponent />);
+
+	jest.spyOn(console, 'log');
+
+	userEvent.tab();
+
+	userEvent.type(screen.getByText('Primary'), '{enter}', {
+		skipClick: true,
+	});
+
+	userEvent.type(screen.getByText('Item 1'), '{space}', {
+		skipClick: true,
+	});
+
+	expect(console.log).toHaveBeenCalledWith('Item one clicked');
+});

--- a/src/use-dropdown-menu.test.tsx
+++ b/src/use-dropdown-menu.test.tsx
@@ -447,7 +447,7 @@ it('Closes the menu after pressing enter on a menu item with a click handler', (
 	expect(screen.getByTestId('is-open-indicator')).toHaveTextContent('false');
 });
 
-it('Activates the click handler of a menu item enter while focused on it', () => {
+it('Activates the click handler of a menu item after pressing enter while focused on it', () => {
 	render(<TestComponent />);
 
 	jest.spyOn(console, 'log');

--- a/src/use-dropdown-menu.ts
+++ b/src/use-dropdown-menu.ts
@@ -140,49 +140,63 @@ export default function useDropdownMenu(itemCount: number): DropdownMenuResponse
 		// Destructure the key property from the event object
 		const { key } = e;
 
-		// Ignore keys that we shouldn't handle
-		if (!['Tab', 'Shift', 'Enter', 'Escape', 'ArrowUp', 'ArrowDown', ' '].includes(key)) {
+		// Handle keyboard controls
+		if (['Tab', 'Shift', 'Enter', 'Escape', 'ArrowUp', 'ArrowDown', ' '].includes(key)) {
+			// Create mutable value that initializes as the currentFocusIndex value
+			let newFocusIndex = currentFocusIndex.current;
+
+			// Controls whether the menu is open or closed, if the button should regain focus on close, and if a handler function should be called
+			if (key === 'Escape') {
+				setIsOpen(false);
+				buttonRef.current?.focus();
+				return;
+			} else if (key === 'Tab') {
+				setIsOpen(false);
+				return;
+			} else if (key === 'Enter' || key === ' ') {
+				if (!e.currentTarget.href) {
+					e.currentTarget.click();
+				}
+
+				setIsOpen(false);
+				return;
+			}
+
+			// Controls the current index to focus
+			if (newFocusIndex !== null) {
+				if (key === 'ArrowUp') {
+					newFocusIndex -= 1;
+				} else if (key === 'ArrowDown') {
+					newFocusIndex += 1;
+				}
+
+				if (newFocusIndex > itemRefs.length - 1) {
+					newFocusIndex = 0;
+				} else if (newFocusIndex < 0) {
+					newFocusIndex = itemRefs.length - 1;
+				}
+			}
+
+			// After any modification set state to the modified value
+			if (newFocusIndex !== null) {
+				moveFocus(newFocusIndex);
+			}
+
 			return;
 		}
 
-		// Create mutable value that initializes as the currentFocusIndex value
-		let newFocusIndex = currentFocusIndex.current;
+		// Handle printable keys
+		if (/[a-zA-Z0-9./<>?;:"'`!@#$%^&*()\\[\]{}_+=|\\-~,]/.test(key)) {
+			const index = itemRefs.findIndex(
+				(ref) =>
+					ref.current?.innerText?.toLowerCase().startsWith(key.toLowerCase()) ||
+					ref.current?.textContent?.toLowerCase().startsWith(key.toLowerCase()) ||
+					ref.current?.getAttribute('aria-label')?.toLowerCase().startsWith(key.toLowerCase())
+			);
 
-		// Controls whether the menu is open or closed, if the button should regain focus on close, and if a handler function should be called
-		if (key === 'Escape') {
-			setIsOpen(false);
-			buttonRef.current?.focus();
-			return;
-		} else if (key === 'Tab') {
-			setIsOpen(false);
-			return;
-		} else if (key === 'Enter' || key === ' ') {
-			if (!e.currentTarget.href) {
-				e.currentTarget.click();
+			if (index !== -1) {
+				moveFocus(index);
 			}
-
-			setIsOpen(false);
-			return;
-		}
-
-		// Controls the current index to focus
-		if (newFocusIndex !== null) {
-			if (key === 'ArrowUp') {
-				newFocusIndex -= 1;
-			} else if (key === 'ArrowDown') {
-				newFocusIndex += 1;
-			}
-
-			if (newFocusIndex > itemRefs.length - 1) {
-				newFocusIndex = 0;
-			} else if (newFocusIndex < 0) {
-				newFocusIndex = itemRefs.length - 1;
-			}
-		}
-
-		// After any modification set state to the modified value
-		if (newFocusIndex !== null) {
-			moveFocus(newFocusIndex);
 		}
 	};
 

--- a/src/use-dropdown-menu.ts
+++ b/src/use-dropdown-menu.ts
@@ -141,7 +141,7 @@ export default function useDropdownMenu(itemCount: number): DropdownMenuResponse
 		const { key } = e;
 
 		// Ignore keys that we shouldn't handle
-		if (!['Tab', 'Shift', 'Enter', 'Escape', 'ArrowUp', 'ArrowDown'].includes(key)) {
+		if (!['Tab', 'Shift', 'Enter', 'Escape', 'ArrowUp', 'ArrowDown', ' '].includes(key)) {
 			return;
 		}
 
@@ -156,7 +156,7 @@ export default function useDropdownMenu(itemCount: number): DropdownMenuResponse
 		} else if (key === 'Tab') {
 			setIsOpen(false);
 			return;
-		} else if (key === 'Enter') {
+		} else if (key === 'Enter' || key === ' ') {
 			if (!e.currentTarget.href) {
 				e.currentTarget.click();
 			}

--- a/website/src/pages/demo.tsx
+++ b/website/src/pages/demo.tsx
@@ -89,7 +89,7 @@ const Demo: React.FC = () => {
 											</li>
 											<li>
 												Pressing any other character will move to the first menu item that starts with that character,
-												if there is not a matching item, focus remains the same.
+												if there is not a matching item, focus remains the same
 											</li>
 										</ul>
 									</li>

--- a/website/src/pages/demo.tsx
+++ b/website/src/pages/demo.tsx
@@ -84,8 +84,12 @@ const Demo: React.FC = () => {
 											</li>
 											<li>Pressing escape will close the menu and return the focus to the button</li>
 											<li>
-												Pressing enter will activate that item and close the menu (whether it’s a link or has a click
-												handler attached)
+												Pressing enter or space will activate that item and close the menu (whether it’s a link or has a
+												click handler attached)
+											</li>
+											<li>
+												Pressing any other character will move to the first menu item that starts with that character,
+												if there is not a matching item, focus remains the same.
 											</li>
 										</ul>
 									</li>


### PR DESCRIPTION
This pull request implements all of the pertinent optional keyboard controls listed on this page: https://www.w3.org/TR/wai-aria-practices/#keyboard-interaction-12

Those include:  

Space: It will now activate menu items and close the menu after activation
Printable characters (not including those that have some other function): Will move the focus to the first menu item whose label starts with the corresponding character

Closes #269 