### PR TITLE
Option to disable focusing first menu item on click

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "react-accessible-dropdown-menu-hook",
-	"version": "2.3.1",
+	"version": "3.3.1",
 	"description": "A simple Hook for creating fully accessible dropdown menus in React",
 	"main": "dist/use-dropdown-menu.js",
 	"types": "dist/use-dropdown-menu.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "react-accessible-dropdown-menu-hook",
-	"version": "3.3.1",
+	"version": "3.0.0",
 	"description": "A simple Hook for creating fully accessible dropdown menus in React",
 	"main": "dist/use-dropdown-menu.js",
 	"types": "dist/use-dropdown-menu.d.ts",

--- a/src/use-dropdown-menu.test.tsx
+++ b/src/use-dropdown-menu.test.tsx
@@ -1,13 +1,17 @@
 // Imports
 import React, { useState } from 'react';
-import useDropdownMenu from './use-dropdown-menu';
+import useDropdownMenu, { DropdownMenuOptions } from './use-dropdown-menu';
 import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 // A mock component for testing the Hook
-const TestComponent: React.FC = () => {
+interface Props {
+	options?: DropdownMenuOptions;
+}
+
+const TestComponent: React.FC<Props> = ({ options }) => {
 	const [itemCount, setItemCount] = useState(4);
-	const { buttonProps, itemProps, isOpen, setIsOpen } = useDropdownMenu(itemCount);
+	const { buttonProps, itemProps, isOpen, setIsOpen } = useDropdownMenu(itemCount, options);
 
 	const clickHandlers: (() => void)[] = [(): void => console.log('Item one clicked'), (): void => setIsOpen(false)];
 
@@ -79,8 +83,8 @@ it('Moves the focus to the first menu item after pressing space while focused on
 	expect(screen.getByText('1 Item')).toHaveFocus();
 });
 
-it('Moves the focus to the first menu item after clicking the menu to open it, then pressing tab while focused on the menu button', () => {
-	render(<TestComponent />);
+it('Moves the focus to the first menu item after clicking the menu to open it, then pressing tab while focused on the menu button, if `disableFocusFirstItemOnClick` is specified', () => {
+	render(<TestComponent options={{ disableFocusFirstItemOnClick: true, }} />);
 
 	userEvent.click(screen.getByText('Primary'));
 
@@ -91,8 +95,8 @@ it('Moves the focus to the first menu item after clicking the menu to open it, t
 	expect(screen.getByText('1 Item')).toHaveFocus();
 });
 
-it('Moves the focus to the first menu item after clicking the menu to open it, then pressing arrow down while focused on the menu button', () => {
-	render(<TestComponent />);
+it('Moves the focus to the first menu item after clicking the menu to open it, then pressing arrow down while focused on the menu button, if `disableFocusFirstItemOnClick` is specified', () => {
+	render(<TestComponent options={{ disableFocusFirstItemOnClick: true, }} />);
 
 	userEvent.click(screen.getByText('Primary'));
 

--- a/src/use-dropdown-menu.test.tsx
+++ b/src/use-dropdown-menu.test.tsx
@@ -83,6 +83,14 @@ it('Moves the focus to the first menu item after pressing space while focused on
 	expect(screen.getByText('1 Item')).toHaveFocus();
 });
 
+it('Moves the focus to the first menu item after clicking the menu to open it', () => {
+	render(<TestComponent />);
+
+	userEvent.click(screen.getByText('Primary'));
+
+	expect(screen.getByText('1 Item')).toHaveFocus();
+});
+
 it('Moves the focus to the first menu item after clicking the menu to open it, then pressing tab while focused on the menu button, if `disableFocusFirstItemOnClick` is specified', () => {
 	render(<TestComponent options={{ disableFocusFirstItemOnClick: true, }} />);
 

--- a/src/use-dropdown-menu.test.tsx
+++ b/src/use-dropdown-menu.test.tsx
@@ -92,7 +92,7 @@ it('Moves the focus to the first menu item after clicking the menu to open it', 
 });
 
 it('Moves the focus to the first menu item after clicking the menu to open it, then pressing tab while focused on the menu button, if `disableFocusFirstItemOnClick` is specified', () => {
-	render(<TestComponent options={{ disableFocusFirstItemOnClick: true, }} />);
+	render(<TestComponent options={{ disableFocusFirstItemOnClick: true }} />);
 
 	userEvent.click(screen.getByText('Primary'));
 
@@ -104,7 +104,7 @@ it('Moves the focus to the first menu item after clicking the menu to open it, t
 });
 
 it('Moves the focus to the first menu item after clicking the menu to open it, then pressing arrow down while focused on the menu button, if `disableFocusFirstItemOnClick` is specified', () => {
-	render(<TestComponent options={{ disableFocusFirstItemOnClick: true, }} />);
+	render(<TestComponent options={{ disableFocusFirstItemOnClick: true }} />);
 
 	userEvent.click(screen.getByText('Primary'));
 

--- a/src/use-dropdown-menu.ts
+++ b/src/use-dropdown-menu.ts
@@ -144,7 +144,7 @@ export default function useDropdownMenu(itemCount: number, options?: DropdownMen
 			if (options?.disableFocusFirstItemOnClick) {
 				clickedOpen.current = !isOpen;
 			}
-			
+
 			setIsOpen(!isOpen);
 		}
 	};

--- a/src/use-dropdown-menu.ts
+++ b/src/use-dropdown-menu.ts
@@ -12,7 +12,7 @@ interface ButtonProps
 
 // A custom Hook that abstracts away the listeners/controls for dropdown menus
 interface DropdownMenuOptions {
-	focusFirstElementOnClick?: boolean;
+	disableFocusFirstItemOnClick?: boolean;
 }
 
 interface DropdownMenuResponse {
@@ -60,7 +60,7 @@ export default function useDropdownMenu(itemCount: number, options?: DropdownMen
 		}
 
 		// If the menu is currently open focus on the first item in the menu
-		if (isOpen && !clickedOpen.current) {
+		if (isOpen && !options?.disableFocusFirstItemOnClick) {
 			moveFocus(0);
 		} else if (!isOpen) {
 			clickedOpen.current = false;
@@ -141,7 +141,10 @@ export default function useDropdownMenu(itemCount: number, options?: DropdownMen
 				setIsOpen(false);
 			}
 		} else {
-			clickedOpen.current = !isOpen;
+			if (options?.disableFocusFirstItemOnClick) {
+				clickedOpen.current = !isOpen;
+			}
+			
 			setIsOpen(!isOpen);
 		}
 	};

--- a/src/use-dropdown-menu.ts
+++ b/src/use-dropdown-menu.ts
@@ -11,7 +11,7 @@ interface ButtonProps
 }
 
 // A custom Hook that abstracts away the listeners/controls for dropdown menus
-interface DropdownMenuOptions {
+export interface DropdownMenuOptions {
 	disableFocusFirstItemOnClick?: boolean;
 }
 

--- a/src/use-dropdown-menu.ts
+++ b/src/use-dropdown-menu.ts
@@ -11,6 +11,10 @@ interface ButtonProps
 }
 
 // A custom Hook that abstracts away the listeners/controls for dropdown menus
+interface DropdownMenuOptions {
+	focusFirstElementOnClick?: boolean;
+}
+
 interface DropdownMenuResponse {
 	readonly buttonProps: ButtonProps;
 	readonly itemProps: {
@@ -23,7 +27,7 @@ interface DropdownMenuResponse {
 	readonly setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-export default function useDropdownMenu(itemCount: number): DropdownMenuResponse {
+export default function useDropdownMenu(itemCount: number, options?: DropdownMenuOptions): DropdownMenuResponse {
 	// Use state
 	const [isOpen, setIsOpen] = useState<boolean>(false);
 	const currentFocusIndex = useRef<number | null>(null);

--- a/test-projects/browser/src/app.test.ts
+++ b/test-projects/browser/src/app.test.ts
@@ -35,13 +35,6 @@ it('Has the correct page title', async () => {
 	await expect(page.title()).resolves.toMatch('Browser');
 });
 
-it('Leaves focus on the button after clicking it', async () => {
-	await page.click('#menu-button');
-	await menuOpen();
-
-	expect(await currentFocusID()).toBe('menu-button');
-});
-
 it('Focuses on the menu button after pressing escape', async () => {
 	await page.focus('#menu-button');
 	await page.keyboard.down('Enter');

--- a/test-projects/browser/src/app.test.ts
+++ b/test-projects/browser/src/app.test.ts
@@ -35,6 +35,13 @@ it('Has the correct page title', async () => {
 	await expect(page.title()).resolves.toMatch('Browser');
 });
 
+it('Focuses the first menu item when menu button is clicked', async () => {
+	await page.click('#menu-button');
+	await menuOpen();
+
+	expect(await currentFocusID()).toBe('menu-item-1');
+});
+
 it('Focuses on the menu button after pressing escape', async () => {
 	await page.focus('#menu-button');
 	await page.keyboard.down('Enter');

--- a/website/docs/design/options.md
+++ b/website/docs/design/options.md
@@ -2,12 +2,12 @@
 title: Options
 ---
 
-This Hook takes in the following options:
+You can customize the behavior with options, passed as the second argument.
 
-```ts
-{
-    disableFocusFirstItemOnClick?: boolean;
-}
-```
+Option | Default | Possible values
+:--- | :--- | :---
+`disableFocusFirstItemOnClick` | `false` | `boolean`
 
-- **disableFocusFirstItemOnClick:** If specified as `true` the default behavior of focusing the first menu item on click will be disabled. The menu button will instead retain focus.
+Option | Explanation
+:--- | :---
+`disableFocusFirstItemOnClick` | If specified as `true` the default behavior of focusing the first menu item on click will be disabled. The menu button will instead retain focus.

--- a/website/docs/design/options.md
+++ b/website/docs/design/options.md
@@ -11,3 +11,9 @@ Option | Default | Possible values
 Option | Explanation
 :--- | :---
 `disableFocusFirstItemOnClick` | If specified as `true` the default behavior of focusing the first menu item on click will be disabled. The menu button will instead retain focus.
+
+```js
+const { buttonProps, itemProps, isOpen, setIsOpen } = useDropdownMenu(numberOfItems, {
+    disableFocusFirstItemOnClick: true,
+});
+```

--- a/website/docs/design/options.md
+++ b/website/docs/design/options.md
@@ -1,0 +1,13 @@
+---
+title: Options
+---
+
+This Hook takes in the following options:
+
+```ts
+{
+    disableFocusFirstItemOnClick?: boolean;
+}
+```
+
+- **disableFocusFirstItemOnClick:** If specified as `true` the default behavior of focusing the first menu item on click will be disabled. The menu button will instead retain focus.

--- a/website/docs/getting-started/using.md
+++ b/website/docs/getting-started/using.md
@@ -2,10 +2,10 @@
 title: Using
 ---
 
-To use the Hook, first call it, telling it how many items your menu will have, and specify any options you want to pass:
+To use the Hook, first call it, telling it how many items your menu will have:
 
 ```jsx
-const { buttonProps, itemProps, isOpen, setIsOpen } = useDropdownMenu(numberOfItems, options);
+const { buttonProps, itemProps, isOpen, setIsOpen } = useDropdownMenu(numberOfItems);
 ```
 
 Take the `buttonProps` object and spread it onto a button:

--- a/website/docs/getting-started/using.md
+++ b/website/docs/getting-started/using.md
@@ -2,10 +2,10 @@
 title: Using
 ---
 
-To use the Hook, first call it, telling it how many items your menu will have:
+To use the Hook, first call it, telling it how many items your menu will have, and specify any options you want to pass:
 
 ```jsx
-const { buttonProps, itemProps, isOpen, setIsOpen } = useDropdownMenu(numberOfItems);
+const { buttonProps, itemProps, isOpen, setIsOpen } = useDropdownMenu(numberOfItems, options);
 ```
 
 Take the `buttonProps` object and spread it onto a button:

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -1,6 +1,6 @@
 module.exports = {
 	default: {
 		'Getting started': ['getting-started/install', 'getting-started/import', 'getting-started/using'],
-		Design: ['design/return-object', 'design/accessibility'],
+		Design: ['design/return-object', 'design/accessibility', 'design/options'],
 	},
 };

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -102,7 +102,7 @@
 	text-decoration: none;
 	cursor: pointer;
 	outline: none;
-	border: 0.1rem solid;
+	border: 0.1rem solid transparent;
 	border-radius: 0.2rem;
 }
 

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -102,7 +102,7 @@
 	text-decoration: none;
 	cursor: pointer;
 	outline: none;
-	border: 0.1rem solid transparent;
+	border: 0.1rem solid;
 	border-radius: 0.2rem;
 }
 
@@ -110,7 +110,16 @@
 	text-decoration: underline;
 }
 
+/* Fallback for browsers that do not support :focus-visible. */
 .demo-menu a:focus {
+	border-color: #3a8eb8;
+}
+
+.demo-menu a:focus:not(:focus-visible) {
+	border-color: transparent;
+}
+
+.demo-menu a:focus-visible {
 	border-color: #3a8eb8;
 }
 

--- a/website/src/pages/demo.tsx
+++ b/website/src/pages/demo.tsx
@@ -65,12 +65,7 @@ const Demo: React.FC = () => {
 										The menu can be revealed by clicking the button, or by focusing the button and pressing enter /
 										space
 									</li>
-									<li>If the menu is revealed with the keyboard, the first menu item is automatically focused</li>
-									<li>
-										If the menu is revealed with the mouse, the first menu item can be focused by pressing tab / arrow
-										down
-									</li>
-									<li>If the menu is revealed with the mouse, the menu can be be closed by pressing escape</li>
+									<li>When the menu is revealed, the first menu item is automatically focused</li>
 									<li>
 										<em>Once focus is in the menu…</em>
 


### PR DESCRIPTION
This pull request does two things. First, it changes the default behavior of the hook to focus the first menu item any time the menu is opened. Second, it introduces an option to disable that behavior, but only for clicks.


https://user-images.githubusercontent.com/42228018/128074615-b34be117-27cc-4957-8785-fe3d2381156c.mp4



Closes #278 
