### PR TITLE
Reduce variables in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ import useDropdownMenu from 'react-accessible-dropdown-menu-hook';
 Call the Hook, telling it how many items your menu will have:
 
 ```tsx
-const { buttonProps, itemProps, isOpen, setIsOpen } = useDropdownMenu(numberOfItems);
+const { buttonProps, itemProps, isOpen } = useDropdownMenu(numberOfItems);
 ```
 
 Spread the `buttonProps` onto a button:

--- a/website/docs/design/options.md
+++ b/website/docs/design/options.md
@@ -13,7 +13,7 @@ Option | Explanation
 `disableFocusFirstItemOnClick` | If specified as `true` the default behavior of focusing the first menu item on click will be disabled. The menu button will instead retain focus.
 
 ```js
-const { buttonProps, itemProps, isOpen, setIsOpen } = useDropdownMenu(numberOfItems, {
+useDropdownMenu(numberOfItems, {
     disableFocusFirstItemOnClick: true,
 });
 ```

--- a/website/docs/getting-started/using.md
+++ b/website/docs/getting-started/using.md
@@ -5,7 +5,7 @@ title: Using
 To use the Hook, first call it, telling it how many items your menu will have:
 
 ```jsx
-const { buttonProps, itemProps, isOpen, setIsOpen } = useDropdownMenu(numberOfItems);
+const { buttonProps, itemProps, isOpen } = useDropdownMenu(numberOfItems);
 ```
 
 Take the `buttonProps` object and spread it onto a button:


### PR DESCRIPTION
Closes #283.

This PR removes `setIsOpen` from a couple of simple code examples, since it's not necessary for basic usage. It also removes variable instantiation from the "Options" page's code example, since the example really only needs to focus on the options (and not the return value).