### PR TITLE
Update doc so it describes the new generic typing

### DIFF
--- a/website/docs/getting-started/using.md
+++ b/website/docs/getting-started/using.md
@@ -2,16 +2,18 @@
 title: Using
 ---
 
-To use the Hook, first call it, telling it how many items your menu will have:
+To use the Hook, first call it, telling it how many items your menu will have along with a valid HTMLElement subtype:
 
 ```jsx
-const { buttonProps, itemProps, isOpen } = useDropdownMenu(numberOfItems);
+const { buttonProps, itemProps, isOpen } = useDropdownMenu<HTMLSubtypeElement>(numberOfItems);
 ```
 
-Take the `buttonProps` object and spread it onto a button:
+Take the `buttonProps` object and spread it onto the corresponding HTML element to your subtype:
 
 ```jsx
 <button {...buttonProps}>Example</button>
+
+<div {...buttonProps}>Example</div>
 ```
 
 Create the menu with the `role='menu'` property and spread `itemProps[x]` onto each item:


### PR DESCRIPTION
useDropdownMenu in the proposed change uses a generic type to allow the use of any HTML element as the “button” so these doc changes will both show the new way to call the hook as well as giving an extra example of a `div` being used.
