### PR TITLE
Additional click handler

### DIFF
--- a/src/use-dropdown-menu.test.tsx
+++ b/src/use-dropdown-menu.test.tsx
@@ -11,7 +11,10 @@ interface Props {
 
 const TestComponent: React.FC<Props> = ({ options }) => {
 	const [itemCount, setItemCount] = useState(4);
-	const { buttonProps, itemProps, isOpen, setIsOpen, moveFocus } = useDropdownMenu(itemCount, options);
+	const { buttonProps, itemProps, isOpen, setIsOpen, moveFocus } = useDropdownMenu<HTMLAnchorElement>(
+		itemCount,
+		options
+	);
 
 	const clickHandlers: (() => void)[] = [(): void => console.log('Item one clicked'), (): void => setIsOpen(false)];
 

--- a/src/use-dropdown-menu.ts
+++ b/src/use-dropdown-menu.ts
@@ -13,6 +13,7 @@ interface ButtonProps<ButtonElement extends HTMLElement>
 // A custom Hook that abstracts away the listeners/controls for dropdown menus
 export interface DropdownMenuOptions {
 	disableFocusFirstItemOnClick?: boolean;
+	handleItemKeyboardSelect?<T extends React.KeyboardEvent<HTMLElement>>(event: T): void;
 }
 
 interface DropdownMenuResponse<ButtonElement extends HTMLElement> {
@@ -186,7 +187,9 @@ export default function useDropdownMenu<ButtonElement extends HTMLElement = HTML
 				setIsOpen(false);
 				return;
 			} else if (key === 'Enter' || key === ' ') {
-				if (!e.currentTarget.href) {
+				if (options?.handleItemKeyboardSelect) {
+					options.handleItemKeyboardSelect(e);
+				} else if (!e.currentTarget.href) {
 					e.currentTarget.click();
 				}
 


### PR DESCRIPTION
I've added an ability to pass custom click handler to options.
Initial behaviour wasn't working for me because I had both `onClick` and `href` on the options so I decided to extend the functionality but preserve the initial API. 

Also:

- moved `moveFocus` to a `useCallback` hook to avoid redeclaring every render, also this helps with dynamically loaded content
- formatted some conditionals for the sake of readability
- shuffled some types around in an attempt to make them more clear because I've had problems with different option types, but this required explicit type argument because I have no idea how to make it resolve automagically