### PR TITLE
Use the runner image (ubuntu) default chrome to prevent jest from failing to find puppeteer's downloaded chromium (and prevent Puppeteer from downloading an unused chromium)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,9 @@ on:
     branches:
       - master
 
+env:
+  PUPPETEER_SKIP_DOWNLOAD: 'true'
+
 jobs:
   lint:
     name: Lint code
@@ -58,6 +61,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - run: yarn dev
+      # ubuntu-latest ships Google Chrome preinstalled; point Puppeteer at it rather than downloading a build, whose extraction has proven unreliable on hosted runners
+      - name: Use the runner's preinstalled Chrome
+        run: |
+          CHROME="$(command -v google-chrome-stable || command -v google-chrome || true)"
+          if [ -z "$CHROME" ]; then
+            echo "::error::No preinstalled Google Chrome found on the runner"
+            exit 1
+          fi
+          echo "Using chrome version $("$CHROME" --version) at $CHROME"
+          echo "PUPPETEER_EXECUTABLE_PATH=$CHROME" >> "$GITHUB_ENV"
       - run: yarn test
       - name: Codecov
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
## Problem

The `test` job has been failing on all PRs since ~late May 2026 (last green run was 2026-04-10). The `test-projects/browser` suite relies on Puppeteer auto-downloading its bundled Chromium during `yarn dev`. A GitHub-runner/Node update (the `current` matrix entry is now Node 26) broke that path: the install still exits 0, but no browser ends up on disk, so jest-puppeteer fails to launch Chrome at test time:

```
spawn .../test-projects/browser/node_modules/puppeteer/.local-chromium/linux-1036745/chrome-linux/chrome ENOENT
```

Nothing in the repo changed — the environment moved underneath a stale, now-EOL dependency (`puppeteer@18.0.3`; npm reports `< 24.15.0 is no longer supported`).

## Fix

Stop depending on the fragile implicit download; instruct Puppeteer to use the Chrome that comes on the runner image through the environment variable it uses to override the executable path (and prevent it from downloading browsers that won't be used).

## Notes

I'd gone through multiple iterations before landing on this being the minimum number of changes. Just having `"allowScripts": { "puppeteer": true }` still leads to an `ENOENT`. Previously, I was downloading a whole separate Chrome, and in so doing, had to force it to run unsandboxed in order to get Puppeteer to work, similar to [what we're introducing over in w3c-css-validator](https://github.com/sparksuite/w3c-css-validator/pull/248/changes#diff-ceb919714c8fee43f06d45e80ec40e0dc755dd8d62453dfb894bc8a24ac341a4). I'm not confident that I can explain _why_, but using the stock Chrome appears to work without needing to do this. Presumably, the host is already well-configured for its stock Chrome, whereas a fresh install isn't configured right - see [the Puppeteer docs](https://pptr.dev/troubleshooting#setting-up-chrome-linux-sandbox) for where this suggestion comes from (but, to be clear, still bold-text explicitly recommends that we use Chrome sandboxed).

The *tradeoff* here is that the Chrome that ships with Puppeteer is ["guaranteed"](https://pptr.dev/guides/configuration) to work with it - but I couldn't figure out a good way to configure the platform to play nicely with Puppeteer, so I think configuring Puppeteer to play nicely with the platform will suffice.

If for whatever reason, there's something different about the CI setup here than in the fork, and this mechanism succeeds in supplying a Chrome to Puppeteer but fails to do so in a way that works (although I expect it to work based on the [same diff](https://github.com/sparksuite/react-accessible-dropdown-menu-hook/compare/master...jmerklinhoae:react-accessible-dropdown-menu-hook:0079176536efafa809748bcefbee86c662205427) running tests [successfully](https://github.com/jmerklinhoae/react-accessible-dropdown-menu-hook/actions/runs/28551169782)), I spent a reasonable chunk of time verifying that we could get any one of 3 different tweaks with different security tradeoffs working - admittedly, with later Puppeteer versions. As an aside, we can definitely jump to `"puppeteer": "^25.3.0",`, `"jest-puppeteer": "^11.0.0",` if we want to without any test code change, but I've elided them from this PR since it's not strictly necessary. ([Branch1](https://github.com/sparksuite/react-accessible-dropdown-menu-hook/compare/master...jmerklinhoae:react-accessible-dropdown-menu-hook:ci-verify) [Branch2](https://github.com/sparksuite/react-accessible-dropdown-menu-hook/compare/master...jmerklinhoae:react-accessible-dropdown-menu-hook:verify-ci-sandbox-flags)).

Those 3 various tweaks, if you're interested:

1. Running the Chrome unsandboxed, as previously alluded to.
2. Running the Chrome sandboxed, but without the AppArmor user namespace restriction, as outlined in option 1 [here](https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md) (note: this 503s semi-frequently for me, but you can refresh until this appears).
3. Running the Chrome sandboxed, but with [some modifications](https://github.com/jmerklinhoae/react-accessible-dropdown-menu-hook/commit/0231f8ce6b69271b1458dcf27190cb657474ed3c) to Chrome's setuid sandbox outlined in option 3 of that same document